### PR TITLE
Do not set DontFragment for UDP socket on MacOS

### DIFF
--- a/DHCPServer/Library/UDPSocket.cs
+++ b/DHCPServer/Library/UDPSocket.cs
@@ -129,7 +129,11 @@ namespace GitHub.JPMikkers.DHCP
             m_Socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
             m_Socket.SendBufferSize = 65536;
             m_Socket.ReceiveBufferSize = 65536;
-            if(!m_IPv6) m_Socket.DontFragment = dontFragment;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                if(!m_IPv6) m_Socket.DontFragment = dontFragment;
+            }
+
             if (ttl >= 0)
             {
                 m_Socket.Ttl = ttl;


### PR DESCRIPTION
this option is not supported on MacOS and causes an exception

Signed-off-by: Michael Malyshev <mikem@zededa.com>